### PR TITLE
Removing tests redundant for simple.testing.AppTest.testFoo1

### DIFF
--- a/src/test/java/simple/testing/AppTest.java
+++ b/src/test/java/simple/testing/AppTest.java
@@ -15,7 +15,7 @@ public class AppTest
         assertEquals(0, a.foo());
     }
 
-    @Test
+    @Test @Ignore @Ignore
     public void testFoo2()
     {
         App a = new App();


### PR DESCRIPTION
This pull request adds @Ignore annotations for skipping tests that are found to be redundant with respect to simple.testing.AppTest.testFoo1
