### PR TITLE
Removing test redundant for simple.testing.AppTest.testFoo1

### DIFF
--- a/src/test/java/simple/testing/AppTest.java
+++ b/src/test/java/simple/testing/AppTest.java
@@ -15,7 +15,7 @@ public class AppTest
         assertEquals(0, a.foo());
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testFoo2()
     {
         App a = new App();


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests simple.testing.AppTest.testFoo1, simple.testing.AppTest.testFoo2 are redundant with respect to one another. In this pull request, we are proposing to keep only the test simple.testing.AppTest.testFoo1 while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.
